### PR TITLE
[#59105032] modify layout and add attribute

### DIFF
--- a/library/res/layout/arc_menu.xml
+++ b/library/res/layout/arc_menu.xml
@@ -1,30 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android" >
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_alignParentBottom="true"
+    android:layout_centerHorizontal="true" >
 
     <com.capricorn.ArcLayout
         xmlns:custom="http://schemas.android.com/apk/res-auto"
         android:id="@+id/item_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        custom:childSize="44px"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        app:childSize="44px"
         custom:fromDegrees="270.0"
-        custom:toDegrees="360.0" />
+        custom:toDegrees="360.0" >
+    </com.capricorn.ArcLayout>
 
-    <FrameLayout
+    <RelativeLayout
         android:id="@+id/control_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
         android:background="@drawable/composer_button" >
 
         <ImageView
             android:id="@+id/control_hint"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
+            android:layout_centerHorizontal="true"
             android:duplicateParentState="true"
             android:src="@drawable/composer_icn_plus" />
-    </FrameLayout>
+    </RelativeLayout>
 
-</merge>
+</RelativeLayout>

--- a/library/res/layout/arc_menu.xml
+++ b/library/res/layout/arc_menu.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_alignParentBottom="true"
-    android:layout_centerHorizontal="true" >
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
 
     <com.capricorn.ArcLayout
         xmlns:custom="http://schemas.android.com/apk/res-auto"
@@ -13,11 +9,10 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
-        app:parentSize="44px"
         app:childSize="44px"
+        app:parentSize="44px"
         custom:fromDegrees="270.0"
-        custom:toDegrees="360.0" >
-    </com.capricorn.ArcLayout>
+        custom:toDegrees="360.0" />
 
     <RelativeLayout
         android:id="@+id/control_layout"
@@ -36,4 +31,4 @@
             android:src="@drawable/composer_icn_plus" />
     </RelativeLayout>
 
-</RelativeLayout>
+</merge>

--- a/library/res/layout/arc_menu.xml
+++ b/library/res/layout/arc_menu.xml
@@ -13,6 +13,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
+        app:parentSize="44px"
         app:childSize="44px"
         custom:fromDegrees="270.0"
         custom:toDegrees="360.0" >

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -3,17 +3,20 @@
     <attr name="fromDegrees" format="float|reference" />
     <attr name="toDegrees" format="float|reference" />
     <attr name="childSize" format="dimension|reference" />
+    <attr name="parentSize" format="dimension|reference" />
 
 	<declare-styleable name="ArcLayout">
         <attr name="fromDegrees"/>
         <attr name="toDegrees"/>
         <attr name="childSize"/>
+        <attr name="parentSize"/>
 	</declare-styleable>
 
     <declare-styleable name="ArcMenu">
         <attr name="fromDegrees"/>
         <attr name="toDegrees"/>
         <attr name="childSize"/>
+        <attr name="parentSize"/>
     </declare-styleable>
 	
 	<declare-styleable name="RayLayout">

--- a/library/src/com/capricorn/ArcLayout.java
+++ b/library/src/com/capricorn/ArcLayout.java
@@ -125,7 +125,7 @@ public class ArcLayout extends ViewGroup {
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         final int centerX = getWidth() / 2;
-        final int centerY = getHeight() / 2;
+        final int centerY = checkTopSemicircular() ? getHeight() - mRadius / 2 - mLayoutPadding : getHeight() / 2;
         final int radius = mExpanded ? mRadius : 0;
 
         final int childCount = getChildCount();
@@ -137,6 +137,10 @@ public class ArcLayout extends ViewGroup {
             degrees += perDegrees;
             getChildAt(i).layout(frame.left, frame.top, frame.right, frame.bottom);
         }
+    }
+
+    private boolean checkTopSemicircular() {
+        return mToDegrees >= 180 && (mToDegrees < 360 || mToDegrees == 0) && mFromDegrees >= 180 && (mFromDegrees < 360 || mFromDegrees == 0);
     }
 
     /**
@@ -202,7 +206,7 @@ public class ArcLayout extends ViewGroup {
     private void bindChildAnimation(final View child, final int index, final long duration) {
         final boolean expanded = mExpanded;
         final int centerX = getWidth() / 2;
-        final int centerY = getHeight() / 2;
+        final int centerY = checkTopSemicircular() ? getHeight() - mRadius / 2 - mLayoutPadding : getHeight() / 2;
         final int radius = expanded ? 0 : mRadius;
 
         final int childCount = getChildCount();

--- a/library/src/com/capricorn/ArcLayout.java
+++ b/library/src/com/capricorn/ArcLayout.java
@@ -48,6 +48,8 @@ public class ArcLayout extends ViewGroup {
 
     private int mChildPadding = 5;
 
+    private int mParentSize;
+
     private int mLayoutPadding = 10;
 
     public static final float DEFAULT_FROM_DEGREES = 270.0f;
@@ -77,6 +79,7 @@ public class ArcLayout extends ViewGroup {
             mFromDegrees = a.getFloat(R.styleable.ArcLayout_fromDegrees, DEFAULT_FROM_DEGREES);
             mToDegrees = a.getFloat(R.styleable.ArcLayout_toDegrees, DEFAULT_TO_DEGREES);
             mChildSize = Math.max(a.getDimensionPixelSize(R.styleable.ArcLayout_childSize, 0), 0);
+            mParentSize = Math.max(a.getDimensionPixelSize(R.styleable.ArcLayout_parentSize, 0), 0);
 
             a.recycle();
         }
@@ -110,7 +113,7 @@ public class ArcLayout extends ViewGroup {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         final int radius = mRadius = computeRadius(Math.abs(mToDegrees - mFromDegrees), getChildCount(), mChildSize,
-                mChildPadding, MIN_RADIUS);
+                mChildPadding, mParentSize);
         final int size = radius * 2 + mChildSize + mChildPadding + mLayoutPadding * 2;
 
         setMeasuredDimension(size, size);
@@ -125,7 +128,7 @@ public class ArcLayout extends ViewGroup {
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         final int centerX = getWidth() / 2;
-        final int centerY = checkTopSemicircular() ? getHeight() - mRadius / 2 - mLayoutPadding : getHeight() / 2;
+        final int centerY = checkTopSemicircular() ? getHeight() - mParentSize / 2 : getHeight() / 2;
         final int radius = mExpanded ? mRadius : 0;
 
         final int childCount = getChildCount();
@@ -206,7 +209,7 @@ public class ArcLayout extends ViewGroup {
     private void bindChildAnimation(final View child, final int index, final long duration) {
         final boolean expanded = mExpanded;
         final int centerX = getWidth() / 2;
-        final int centerY = checkTopSemicircular() ? getHeight() - mRadius / 2 - mLayoutPadding : getHeight() / 2;
+        final int centerY = checkTopSemicircular() ? getHeight() - mParentSize / 2 : getHeight() / 2;
         final int radius = expanded ? 0 : mRadius;
 
         final int childCount = getChildCount();
@@ -279,6 +282,20 @@ public class ArcLayout extends ViewGroup {
 
     public int getChildSize() {
         return mChildSize;
+    }
+
+    public void setParentSize(int size) {
+        if (mParentSize == size || size < 0) {
+            return;
+        }
+
+        mParentSize = size;
+
+        requestLayout();
+    }
+
+    public int getParentSize() {
+        return mParentSize;
     }
 
     /**

--- a/library/src/com/capricorn/ArcMenu.java
+++ b/library/src/com/capricorn/ArcMenu.java
@@ -45,6 +45,8 @@ public class ArcMenu extends RelativeLayout {
 
     private ImageView mHintView;
 
+    private ViewGroup mControlLayout;
+
     public ArcMenu(Context context) {
         super(context);
         init(context);
@@ -62,9 +64,9 @@ public class ArcMenu extends RelativeLayout {
 
         mArcLayout = (ArcLayout) findViewById(R.id.item_layout);
 
-        final ViewGroup controlLayout = (ViewGroup) findViewById(R.id.control_layout);
-        controlLayout.setClickable(true);
-        controlLayout.setOnTouchListener(new OnTouchListener() {
+        mControlLayout = (ViewGroup) findViewById(R.id.control_layout);
+        mControlLayout.setClickable(true);
+        mControlLayout.setOnTouchListener(new OnTouchListener() {
 
             @Override
             public boolean onTouch(View v, MotionEvent event) {
@@ -91,6 +93,13 @@ public class ArcMenu extends RelativeLayout {
             int defaultChildSize = mArcLayout.getChildSize();
             int newChildSize = a.getDimensionPixelSize(R.styleable.ArcLayout_childSize, defaultChildSize);
             mArcLayout.setChildSize(newChildSize);
+            int defaultParentSize = mArcLayout.getParentSize();
+            int newParentSize = a.getDimensionPixelSize(R.styleable.ArcLayout_parentSize, defaultParentSize);
+            mArcLayout.setParentSize(newParentSize);
+
+            LayoutParams params = (LayoutParams) mControlLayout.getLayoutParams();
+            params.width = params.height = newParentSize;
+            mControlLayout.setLayoutParams(params);
 
             a.recycle();
         }


### PR DESCRIPTION
reviewer: @jyukon
https://www.pivotaltracker.com/story/show/59105032

変更点です。
- コマンダーのメインボタンがViewの真ん中固定で、画面の最下位に表示することが難しい
  -  arcの角度の指定がfromDegrees/toDegreesが共に180〜360の場合（上に弧がくる半円の場合）はViewの下方に表示する
- 親のボタン画像の後ろに子のボタン画像がうまく隠れない
  - 親のボタン画像のサイズをattributeとして追加し、表示位置の計算に使う

前提として、今回のコマンダーのデザイン固定で実装しました（汎用性は考えていません）。

下記とあわせてレビューください。
https://github.com/tonchidot/tab-android-client/pull/766
